### PR TITLE
Refactor critical areas and improve overall stability.

### DIFF
--- a/migrations/2025-04-15-220141_create_sysinfo/down.sql
+++ b/migrations/2025-04-15-220141_create_sysinfo/down.sql
@@ -1,1 +1,1 @@
--- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS sysinfo;

--- a/migrations/2025-04-22-205243_add_salt_user/down.sql
+++ b/migrations/2025-04-22-205243_add_salt_user/down.sql
@@ -1,3 +1,1 @@
--- This file should undo anything in `up.sql`
-ALTER TABLE users
-    DROP COLUMN salt;
+ALTER TABLE user DROP COLUMN salt;

--- a/src/config/handlers.rs
+++ b/src/config/handlers.rs
@@ -5,26 +5,50 @@ use crate::{
     },
     monitor::storage::Storage,
 };
-use actix_web::{HttpResponse, Responder, get};
+use actix_web::{get, web, Error, HttpResponse, Responder};
+use actix_web::error::ErrorInternalServerError;
 
 #[get("/teus-config")]
-pub async fn get_teus_config(config: actix_web::web::Data<Config>) -> impl Responder {
-    let storage = Storage::new(&config.database.path).unwrap();
-    let mut conn = storage.diesel_conn.lock().unwrap();
-    let latest_teusconfig_option = schema::TeusConfig::get_teus_server_config(&mut *conn).unwrap();
+pub async fn get_teus_config(
+    config: web::Data<Config>,
+) -> Result<HttpResponse, Error> {
+    let storage = Storage::new(&config.database.path).map_err(|e| {
+        eprintln!("Failed to initialize storage: {:?}", e); // TODO: Use log::error!
+        ErrorInternalServerError("Failed to initialize storage")
+    })?;
+    let mut conn = storage.diesel_conn.lock().map_err(|_| {
+        eprintln!("Mutex poisoned while getting Teus config"); // TODO: Use log::error!
+        ErrorInternalServerError("Failed to acquire database lock")
+    })?;
+    let latest_teusconfig_option =
+        schema::TeusConfig::get_teus_server_config(&mut *conn).map_err(|e| {
+            eprintln!("Database error getting Teus config: {:?}", e); // TODO: Use log::error!
+            ErrorInternalServerError("Error fetching TeusConfig")
+        })?;
 
     match latest_teusconfig_option {
-        Some(teus_config) => HttpResponse::Ok().json(teus_config),
-        None => HttpResponse::NotFound().json("No TeusConfig found"),
+        Some(teus_config) => Ok(HttpResponse::Ok().json(teus_config)),
+        None => Ok(HttpResponse::NotFound().json("No TeusConfig found")),
     }
 }
 
 #[get("/teus-config/first-visit")]
-pub async fn is_first_visit(config: actix_web::web::Data<Config>) -> impl Responder {
-    let storage = Storage::new(&config.database.path).unwrap();
-    let mut conn = storage.diesel_conn.lock().unwrap();
-    let first_visit = schema::TeusConfig::is_first_visit(&mut *conn).unwrap();
+pub async fn is_first_visit(
+    config: web::Data<Config>,
+) -> Result<HttpResponse, Error> {
+    let storage = Storage::new(&config.database.path).map_err(|e| {
+        eprintln!("Failed to initialize storage for first-visit check: {:?}", e); // TODO: Use log::error!
+        ErrorInternalServerError("Failed to initialize storage")
+    })?;
+    let mut conn = storage.diesel_conn.lock().map_err(|_| {
+        eprintln!("Mutex poisoned while checking first visit"); // TODO: Use log::error!
+        ErrorInternalServerError("Failed to acquire database lock")
+    })?;
+    let first_visit = schema::TeusConfig::is_first_visit(&mut *conn).map_err(|e| {
+        eprintln!("Database error checking first visit: {:?}", e); // TODO: Use log::error!
+        ErrorInternalServerError("Error checking first visit status")
+    })?;
 
     let response = IsFirstVisitResponse { first_visit };
-    HttpResponse::Ok().json(response)
+    Ok(HttpResponse::Ok().json(response))
 }

--- a/src/monitor/storage.rs
+++ b/src/monitor/storage.rs
@@ -1,8 +1,11 @@
 use diesel::{Connection as ConnectionDiesel, SqliteConnection};
-use rusqlite::{Connection, Result};
+use diesel::connection::SimpleConnection; // Added
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::error::Error; // Added for Box<dyn Error>
+
+// Removed: use rusqlite::{Connection, Result};
+// Removed: use std::time::Duration;
 
 #[derive(Clone)]
 pub struct Storage {
@@ -17,68 +20,34 @@ mod storage_utils {
         let dir_path = Path::new(path);
         if !dir_path.exists() {
             fs::create_dir_all(dir_path)?;
-            println!("Directory '{}' created.", path);
+            // Consider using log crate for messages instead of println!
+            // println!("Directory '{}' created.", path); 
         }
         Ok(())
     }
 }
 
-// TODO: Migrate Connection -> SqliteConnection
+// TODO: Migrate Connection -> SqliteConnection // This TODO can be removed after this refactor
 impl Storage {
-    pub fn new(db_path: &str) -> rusqlite::Result<Self> {
+    pub fn new(db_path: &str) -> Result<Self, Box<dyn Error>> { // Changed return type
         if let Some(parent) = Path::new(db_path).parent() {
             if let Some(parent_str) = parent.to_str() {
-                storage_utils::ensure_directory_exists(parent_str)
-                    .expect("Failed to create parent directory");
+                storage_utils::ensure_directory_exists(parent_str)?; // Changed from expect
             }
         }
 
-        let conn = Connection::open(db_path)?;
-        let conn_new = SqliteConnection::establish(&db_path)
-            .unwrap_or_else(|e| panic!("Failed to connect, error: {}", e));
+        // Removed rusqlite connection logic
 
-        // Enable WAL mode for better concurrency
-        conn.execute_batch("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;")?;
+        let mut conn_new = SqliteConnection::establish(&db_path)?; // Changed from unwrap_or_else
 
-        // Set a busy timeout to wait instead of immediately failing
-        conn.busy_timeout(Duration::from_secs(5))?;
+        // Apply PRAGMAs to Diesel connection
+        // Note: busy_timeout is set in milliseconds for SQLite PRAGMA
+        conn_new.batch_execute("PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;")?;
 
         Ok(Self {
             diesel_conn: Arc::new(Mutex::new(conn_new)),
         })
     }
 
-    /// Initialize the database, by default it creates the tables if they don't exist.
-    /// Otherwise it does nothing.
-    #[deprecated = "Now uses Diesel migrations instead"]
-    pub fn _init_db(&self, conn: &Connection) -> Result<()> {
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS sysinfo (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            timestamp TEXT NOT NULL,
-            cpu_usage REAL NOT NULL,
-            ram_usage REAL NOT NULL,
-            total_ram REAL NOT NULL,
-            free_ram REAL NOT NULL,
-            used_swap REAL NOT NULL
-        )",
-            [],
-        )?;
-
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS diskinfo (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            sysinfo_id INTEGER NOT NULL,
-            filesystem TEXT NOT NULL,
-            size INTEGER NOT NULL,
-            used INTEGER NOT NULL,
-            available INTEGER NOT NULL,
-            used_percentage INTEGER NOT NULL,
-            mounted_path TEXT NOT NULL,
-            FOREIGN KEY (sysinfo_id) REFERENCES sysinfo(id)
-        )",
-            [],
-        )?;
-        Ok(())
-    }
+    // Removed _init_db method
 }

--- a/src/webserver/api.rs
+++ b/src/webserver/api.rs
@@ -6,28 +6,22 @@ use crate::webserver::models::sysmodels::{DiskInfoResponse, SysInfoResponse};
 use crate::webserver::services::systeminfo;
 use crate::{config::types::Config, monitor::storage::Storage};
 use actix_cors::Cors;
-use actix_web::{App, HttpResponse, HttpServer, Responder, get, http, middleware, web};
+use actix_web::{get, http, middleware, web, App, Error, HttpResponse, HttpServer, Responder};
+use actix_web::error::ErrorInternalServerError;
 
 #[get("/sysinfo")]
-async fn sysinfo_handler(config: actix_web::web::Data<Config>) -> impl Responder {
-    let storage = match Storage::new(&config.database.path) {
-        Ok(storage) => storage,
-        Err(e) => {
-            eprintln!("Failed to create storage: {}", e);
-            return HttpResponse::InternalServerError().json("Failed to connect to database");
-        }
-    };
+async fn sysinfo_handler(storage: web::Data<Storage>) -> Result<HttpResponse, Error> {
+    let mut conn = storage.diesel_conn.lock().map_err(|_| {
+        eprintln!("Mutex poisoned while getting sysinfo"); // TODO: Use log::error!
+        ErrorInternalServerError("Failed to acquire database lock")
+    })?;
 
-    let mut conn = storage.diesel_conn.lock().unwrap();
-    let sys_info = match query::get_latest_sysinfo_with_disks(&mut conn) {
-        Ok(sys_info) => sys_info,
-        Err(e) => {
-            eprintln!("Failed to get latest sysinfo: {}", e);
-            return HttpResponse::InternalServerError().json("Failed to get latest sysinfo");
-        }
-    };
+    let sys_info_result = query::get_latest_sysinfo_with_disks(&mut conn).map_err(|e| {
+        eprintln!("Database error getting sysinfo: {:?}", e); // TODO: Use log::error!
+        ErrorInternalServerError("Failed to get latest sysinfo")
+    })?;
 
-    if let Some((sys_info, disks)) = sys_info {
+    if let Some((sys_info, disks)) = sys_info_result {
         let timestamp = sys_info.timestamp.clone();
         let disks = disks
             .iter()
@@ -50,20 +44,22 @@ async fn sysinfo_handler(config: actix_web::web::Data<Config>) -> impl Responder
             disks: disks,
         };
 
-        HttpResponse::Ok().json(response)
+        Ok(HttpResponse::Ok().json(response))
     } else {
-        HttpResponse::NotFound().json("No sysinfo found")
+        Ok(HttpResponse::NotFound().json("No sysinfo found"))
     }
 }
 
 #[actix_web::main]
-pub async fn start_webserver(config: &Config) -> std::io::Result<()> {
+pub async fn start_webserver(config: &Config, storage: Storage) -> std::io::Result<()> {
     let url = format!("{}:{}", config.server.host, config.server.port);
     println!("Webserver listening on {}", url);
 
-    let config_data = config.clone();
+    let app_config_data = web::Data::new(config.clone());
+    let app_storage_data = web::Data::new(storage.clone()); // Clone for app_data
+
     // TODO: Put the secret here from the config
-    let jwt_secret = config_data.server.secret.clone();
+    let jwt_secret = config.server.secret.clone();
     let jwt_config = web::Data::new(JwtConfig {
         secret: jwt_secret.to_string(),
         expiration_hours: 24,
@@ -80,8 +76,9 @@ pub async fn start_webserver(config: &Config) -> std::io::Result<()> {
         App::new()
             .wrap(middleware::Logger::default())
             .wrap(cors)
-            .app_data(actix_web::web::Data::new(config_data.clone()))
-            .app_data(jwt_config.clone())
+            .app_data(app_config_data.clone()) // Share config
+            .app_data(app_storage_data.clone()) // Share storage
+            .app_data(jwt_config.clone()) // Share JWT config
             // Public routes
             .service(
                 web::scope("/api/v1/auth")

--- a/teus.service
+++ b/teus.service
@@ -3,9 +3,12 @@ Description=Teus - Monitoring service
 After=network.target
 
 [Service]
+User=teus
+Group=teus
 ExecStart=/usr/local/bin/teus /etc/systemd/teus.toml
 KillSignal=SIGINT
 TimeoutStopSec=10
+ReadWritePaths=/var/lib/teus
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This commit includes the following changes:

- Fix critical errors in database migration rollback scripts (`down.sql` for sysinfo table and user salt column).
- Improve error handling in `src/config/handlers.rs` by replacing `unwrap()` calls with proper error mapping to Actix web errors, ensuring HTTP 500 responses on internal failures.
- Refactor `Storage` initialization for the webserver:
    - `Storage` is now initialized once in `main.rs`.
    - The shared `Storage` instance is passed to Actix handlers via `app_data`.
    - `sysinfo_handler` in `webserver/api.rs` now uses the shared instance and has improved error handling.
- Enhance security by preparing for unprivileged service execution:
    - `install.sh` modified to create a 'teus' system user/group.
    - Database directory (`/var/lib/teus`) creation and permission settings for the 'teus' user added to `install.sh`.
    - Temporary `.env` file is now cleaned up in `install.sh`.
    - `teus.service` modified to run the service as `User=teus` and `Group=teus`.
    - Added `ReadWritePaths=/var/lib/teus` to `teus.service` for stricter filesystem permissions.
- Refactor `src/monitor/storage.rs` to remove `rusqlite` dependency:
    - All database connection logic now uses Diesel.
    - PRAGMA settings (WAL mode, synchronous, busy_timeout) are applied to the Diesel `SqliteConnection`.
    - Error handling in `Storage::new` is improved.
    - Deprecated `_init_db` method (which used `rusqlite`) removed.